### PR TITLE
Forcessl redirects to wrong url if dokuwiki not running as root of webserver.

### DIFF
--- a/action.php
+++ b/action.php
@@ -33,7 +33,7 @@ class action_plugin_forcessllogin extends DokuWiki_Action_Plugin {
     if( is_ssl( )) return;
 
     if( $event->name == 'ACTION_ACT_PREPROCESS' && !$this->getConf('splashpage')) {
-      send_redirect( 'https://'.$this->host( ).'/'.DOKU_SCRIPT. '?'. $_SERVER['QUERY_STRING'] );
+      send_redirect( 'https://'.$this->host( ).DOKU_BASE.DOKU_SCRIPT. '?'. $_SERVER['QUERY_STRING'] );
       exit;
     }
     if( $event->name == 'TPL_ACT_RENDER' ) {
@@ -46,7 +46,7 @@ class action_plugin_forcessllogin extends DokuWiki_Action_Plugin {
   function _render( $act ) {
     global $ID;
     $form = new Doku_Form(array('id'=>'forcessllogin1',
-        'action' => 'https://'.$this->host( ).'/'.DOKU_SCRIPT,
+        'action' => 'https://'.$this->host( ).DOKU_BASE.DOKU_SCRIPT,
         'method' => 'get'));
      $form->addHidden( 'id', $ID );
      $form->addHidden( 'do', $act );


### PR DESCRIPTION
IE if running dokuwiki at http://example.com/dokuwiki/ then forcessl redirects to https://example.com/doku.php instead of https://example.com/dokuwiki/doku.php. This commit fixes that.
