### PR TITLE
Makes the plugin PHP7 ready

### DIFF
--- a/action.php
+++ b/action.php
@@ -21,7 +21,7 @@ class action_plugin_forcessllogin extends DokuWiki_Action_Plugin {
         'url'    => 'http://www.dokuwiki.org/plugin:forcessllogin',
     );
   }
-  function register(&$controller) {
+  function register(Doku_Event_Handler $controller) {
     $controller->register_hook('TPL_ACT_RENDER', 'BEFORE',  $this, 'forcessllogin');
     $controller->register_hook('ACTION_ACT_PREPROCESS', 'BEFORE',  $this, 'forcessllogin');
   }


### PR DESCRIPTION
Fixes this error

Warning: Declaration of action_plugin_forcessllogin::register(&$controller) should be compatible with DokuWiki_Action_Plugin::register(Doku_Event_Handler $controller) in /dwtest/lib/plugins/forcessllogin/action.php on line 91
