### PR TITLE
Rewritten URL has redundant DokuWiki directory

### DIFF
--- a/action.php
+++ b/action.php
@@ -86,6 +86,7 @@ class action_plugin_forcessllogin extends DokuWiki_Action_Plugin {
   }
   function _path( ) {
     $base = str_replace( 'http://', 'https://', getBaseUrl( 'absolute' ));
+    $base = rtrim($base, getBaseUrl());  # right trim the dokuwiki directory from the base URL
     $path = $_SERVER['REQUEST_URI'];
     return $base.$path;
   }


### PR DESCRIPTION
The base URL given by `getBaseUrl` and `path` given by `REQUEST_URI` from `$_SERVER` array both include DokuWiki directory (or `/` if it is installed in the root directory)[1] causing the resulting concatenation of these two has redundant directory part; e.g. assume that the DokuWiki is install in the `/dokuwiki/` directory of domain `example.com`. The resulting URL would be:

```
https://example.com/dokuwiki//dokuwiki/doku.php?id=start&do=login     # 404 not found
```

or if it is installed in the root directory, the resulting URL would have redundant slashes which doesn't any harm:

```
https://example.com//doku.php?id=start&do=login
```

Right trim the DokuWiki directory from the base URL would fix the problem.

[1] https://xref.dokuwiki.org/reference/dokuwiki/nav.html?inc/init.php.source.html#l430
